### PR TITLE
added totals row and flexed the table rows

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -9,16 +9,16 @@ import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 
 import Demo from '../examples/Demo.tsx';
+import FlexScrollDemo from '../examples/FlexScrollDemo.tsx';
 
 const DemoCode = require('!raw-loader!../examples/Demo.tsx').default;
+const FlexScrollDemoCode = require('!raw-loader!../examples/FlexScrollDemo.tsx').default;
 
 const Code = props => (
   <React.Fragment>
     <Divider style={{ marginTop: '18px' }} />
     <Box mt={2} p={2} boxShadow={2} bgcolor="background.paper">
-      <Typography variant="subtitle2">
-        EXAMPLE CODE
-      </Typography>
+      <Typography variant="subtitle2">EXAMPLE CODE</Typography>
       <Box
         component="pre"
         p={1}
@@ -35,7 +35,7 @@ const Code = props => (
 const MUIWrapper = storyFn => (
   <React.Fragment>
     <CssBaseline />
-    <Container maxWidth="xl" style={{ padding: '18px 0'}}>
+    <Container maxWidth="xl" style={{ padding: '18px 0' }}>
       {storyFn()}
     </Container>
   </React.Fragment>
@@ -50,6 +50,19 @@ storiesOf('Example', module)
           <Demo />
         </main>
         <Code>{DemoCode}</Code>
+      </React.Fragment>
+    );
+  });
+
+storiesOf('Example', module)
+  .addDecorator(MUIWrapper)
+  .add('Flex-Scroll Table', () => {
+    return (
+      <React.Fragment>
+        <main>
+          <FlexScrollDemo />
+        </main>
+        <Code>{FlexScrollDemoCode}</Code>
       </React.Fragment>
     );
   });

--- a/examples/FlexScrollDemo.tsx
+++ b/examples/FlexScrollDemo.tsx
@@ -1,0 +1,212 @@
+import 'material-icons/iconfont/material-icons.css';
+
+import { Grid } from '@material-ui/core';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import { createMuiTheme } from '@material-ui/core/styles';
+import React, { Component } from 'react';
+import MaterialTable from 'material-ui-advanced-table';
+
+import SampleTotalsRow from './SampleTotalsRow';
+
+let direction: 'ltr' | 'rtl' = 'ltr';
+
+const theme = createMuiTheme({
+  direction: direction,
+  palette: {
+    type: 'light',
+  },
+});
+
+const bigData: any[] = [];
+for (let i = 0; i < 1; i++) {
+  const d = {
+    id: i + 1,
+    name: 'Name' + i,
+    surname: 'Surname' + Math.round(i / 10),
+    isMarried: i % 2 ? true : false,
+    birthDate: new Date(1987, 1, 1),
+    birthCity: 0,
+    sex: i % 2 ? 'Male' : 'Female',
+    type: 'adult',
+    insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+    time: new Date(1900, 1, 1, 14, 23, 35),
+  };
+  bigData.push(d);
+}
+
+class Demo extends Component<any, any> {
+  inputBProps: any;
+  tableRef: any = React.createRef();
+  colRenderCount = 0;
+
+  state = {
+    text: 'text',
+    selecteds: 0,
+    data: [
+      {
+        id: 1,
+        name: 'A1',
+        surname: 'B',
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 0,
+        sex: 'Male',
+        type: 'adult',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+      },
+      {
+        id: 2,
+        name: 'A2',
+        surname: 'B',
+        isMarried: false,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: 'Female',
+        type: 'adult',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 1,
+      },
+      {
+        id: 3,
+        name: 'A3',
+        surname: 'B',
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: 'Female',
+        type: 'child',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 1,
+      },
+      {
+        id: 4,
+        name: 'A4',
+        surname: 'C',
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: 'Female',
+        type: 'child',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 3,
+      },
+      {
+        id: 5,
+        name: 'A5',
+        surname: 'C',
+        isMarried: false,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: 'Female',
+        type: 'child',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+      },
+      {
+        id: 6,
+        name: 'A6',
+        surname: 'C',
+        isMarried: true,
+        birthDate: new Date(1989, 1, 1),
+        birthCity: 34,
+        sex: 'Female',
+        type: 'child',
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 5,
+      },
+    ],
+    columns: [
+      {
+        title: 'Adı',
+        field: 'name',
+        editComponent: props => {
+          return (
+            <input
+              value={props.value}
+              onChange={e => {
+                var data = { ...props.rowData };
+                data.name = e.target.value;
+                data.surname = e.target.value.toLocaleUpperCase();
+                props.onRowDataChange(data);
+              }}
+            />
+          );
+        },
+      },
+      {
+        title: 'Soyadı',
+        field: 'surname',
+        editComponent: props => {
+          this.inputBProps = props;
+          return (
+            <input value={props.value} onChange={e => props.onChange(e.target.value)} />
+          );
+        },
+      },
+      { title: 'Evli', field: 'isMarried', type: 'boolean' },
+      { title: 'Cinsiyet', field: 'sex', disableClick: true, editable: 'onAdd' },
+      { title: 'Tipi', field: 'type', removable: false, editable: 'never' },
+      { title: 'Doğum Yılı', field: 'birthDate', type: 'date' },
+      {
+        title: 'Doğum Yeri',
+        field: 'birthCity',
+        lookup: { 34: 'İstanbul', 0: 'Şanlıurfa' },
+      },
+      { title: 'Kayıt Tarihi', field: 'insertDateTime', type: 'datetime' },
+      { title: 'Zaman', field: 'time', type: 'time' },
+    ],
+    remoteColumns: [
+      {
+        title: 'Avatar',
+        field: 'avatar',
+        render: rowData => (
+          <img style={{ height: 36, borderRadius: '50%' }} src={rowData.avatar} />
+        ),
+      },
+      { title: 'Id', field: 'id' },
+      { title: 'First Name', field: 'first_name', defaultFilter: 'De' },
+      { title: 'Last Name', field: 'last_name' },
+    ],
+  };
+
+  render() {
+    return (
+      <>
+        <MuiThemeProvider theme={theme}>
+          <div
+            style={{
+              maxWidth: '100%',
+              direction,
+            }}
+          >
+            <Grid container>
+              <Grid item xs={12}>
+                <MaterialTable
+                  tableRef={this.tableRef}
+                  columns={this.state.columns}
+                  data={this.state.data}
+                  title="Flex Scroll And Totals Row Demo"
+                  options={{
+                    selection: true,
+                    flexTable: true,
+                  }}
+                  style={{
+                    minHeight: '300px',
+                  }}
+                  preFooterRow={<SampleTotalsRow />}
+                />
+              </Grid>
+            </Grid>
+          </div>
+        </MuiThemeProvider>
+      </>
+    );
+  }
+}
+
+export default Demo;

--- a/examples/SampleTotalsRow.tsx
+++ b/examples/SampleTotalsRow.tsx
@@ -1,0 +1,73 @@
+// General
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
+
+// MUI Imports
+import { Table, TableCell, TableHead, TableRow, Typography } from '@material-ui/core';
+
+// Local components
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    boldText: {
+      fontWeight: 'bold',
+    },
+    totalsTable: {
+      backgroundColor: `${theme.palette.grey[200]}`,
+    },
+    totalsTableRowHeight: {
+      height: '32px',
+    },
+    totalsTableTitle: {
+      minWidth: '60px',
+    },
+  })
+);
+
+const ConversationTotals: React.FC = () => {
+  const classes = useStyles({});
+
+  return (
+    <Table className={classes.totalsTable}>
+      <TableHead>
+        <TableRow className={classes.totalsTableRowHeight}>
+          <TableCell
+            align={'center'}
+            padding={'none'}
+            className={classes.totalsTableTitle}
+          >
+            <Typography variant="caption" className={classes.boldText} color="primary">
+              {'TOTALS'}
+            </Typography>
+          </TableCell>
+
+          <TableCell align={'left'} padding={'none'}>
+            <Typography variant="caption" className={classes.boldText}>
+              {'Groups'}: 15
+            </Typography>
+          </TableCell>
+
+          <TableCell align={'left'} padding={'none'}>
+            <Typography variant="caption" className={classes.boldText}>
+              {'Campaigns'}: 3
+            </Typography>
+          </TableCell>
+
+          <TableCell align={'left'} padding={'none'}>
+            <Typography variant="caption" className={classes.boldText}>
+              {'Messages'}: 456
+            </Typography>
+          </TableCell>
+
+          <TableCell align={'left'} padding={'none'}>
+            <Typography variant="caption" className={classes.boldText}>
+              {'Agents'}: 8
+            </Typography>
+          </TableCell>
+        </TableRow>
+      </TableHead>
+    </Table>
+  );
+};
+
+export default ConversationTotals;

--- a/src/default-props.tsx
+++ b/src/default-props.tsx
@@ -5,17 +5,32 @@ import PropTypes from 'prop-types';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 
 const OverlayLoading = props => (
-  <div style={{ display: 'table', width: '100%', height: '100%', backgroundColor: fade(props.theme.palette.background.paper, 0.7) }}>
-    <div style={{ display: 'table-cell', width: '100%', height: '100%', verticalAlign: 'middle', textAlign: 'center' }}>
+  <div
+    style={{
+      display: 'table',
+      width: '100%',
+      height: '100%',
+      backgroundColor: fade(props.theme.palette.background.paper, 0.7),
+    }}
+  >
+    <div
+      style={{
+        display: 'table-cell',
+        width: '100%',
+        height: '100%',
+        verticalAlign: 'middle',
+        textAlign: 'center',
+      }}
+    >
       <CircularProgress />
     </div>
   </div>
 );
 OverlayLoading.propTypes = {
-  theme: PropTypes.any
+  theme: PropTypes.any,
 };
 
-const Container = (props) => <Paper elevation={2} {...props}/>;
+const Container = props => <Paper elevation={2} {...props} />;
 
 export const defaultProps = {
   actions: [],
@@ -36,27 +51,95 @@ export const defaultProps = {
     OverlayLoading: OverlayLoading,
     Pagination: TablePagination,
     Row: MComponents.MTableBodyRow,
-    Toolbar: MComponents.MTableToolbar
+    Toolbar: MComponents.MTableToolbar,
   },
   data: [],
   icons: {
-    Add: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>add_box</Icon>),
-    Check: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>check</Icon>),
-    Clear: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>clear</Icon>),
-    Delete: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>delete_outline</Icon>),
-    DetailPanel: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_right</Icon>),
-    Edit: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>edit</Icon>),
-    Export: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>save_alt</Icon>),
-    Filter: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>filter_list</Icon>),
-    FirstPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>first_page</Icon>),
-    LastPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>last_page</Icon>),
-    NextPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_right</Icon>),
-    PreviousPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_left</Icon>),
-    ResetSearch: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>clear</Icon>),
-    Search: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>search</Icon>),
-    SortArrow: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>arrow_upward</Icon>),
-    ThirdStateCheck: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>remove</Icon>),
-    ViewColumn: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>view_column</Icon>)
+    Add: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        add_box
+      </Icon>
+    )),
+    Check: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        check
+      </Icon>
+    )),
+    Clear: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        clear
+      </Icon>
+    )),
+    Delete: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        delete_outline
+      </Icon>
+    )),
+    DetailPanel: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        chevron_right
+      </Icon>
+    )),
+    Edit: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        edit
+      </Icon>
+    )),
+    Export: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        save_alt
+      </Icon>
+    )),
+    Filter: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        filter_list
+      </Icon>
+    )),
+    FirstPage: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        first_page
+      </Icon>
+    )),
+    LastPage: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        last_page
+      </Icon>
+    )),
+    NextPage: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        chevron_right
+      </Icon>
+    )),
+    PreviousPage: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        chevron_left
+      </Icon>
+    )),
+    ResetSearch: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        clear
+      </Icon>
+    )),
+    Search: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        search
+      </Icon>
+    )),
+    SortArrow: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        arrow_upward
+      </Icon>
+    )),
+    ThirdStateCheck: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        remove
+      </Icon>
+    )),
+    ViewColumn: React.forwardRef((props, ref) => (
+      <Icon {...props} ref={ref}>
+        view_column
+      </Icon>
+    )),
   },
   isLoading: false,
   title: 'Table Title',
@@ -92,7 +175,8 @@ export const defaultProps = {
     sorting: true,
     toolbar: true,
     defaultExpanded: false,
-    detailPanelColumnAlignment: 'left'
+    detailPanelColumnAlignment: 'left',
+    flexTable: false,
   },
   localization: {
     grouping: {
@@ -102,7 +186,7 @@ export const defaultProps = {
     pagination: {
       labelDisplayedRows: '{from}-{to} of {count}',
       labelRowsPerPage: 'Rows per page:',
-      labelRowsSelect: 'rows'
+      labelRowsSelect: 'rows',
     },
     toolbar: {},
     header: {},
@@ -115,9 +199,9 @@ export const defaultProps = {
       },
       addTooltip: 'Add',
       deleteTooltip: 'Delete',
-      editTooltip: 'Edit'
-    }
+      editTooltip: 'Edit',
+    },
   },
-  style: {
-  }
+  style: {},
+  preFooterRow: null,
 };

--- a/src/material-table.tsx
+++ b/src/material-table.tsx
@@ -1,5 +1,5 @@
 import { Table, TableFooter, TableRow, LinearProgress } from '@material-ui/core';
-import DoubleScrollbar from "react-double-scrollbar";
+import DoubleScrollbar from 'react-double-scrollbar';
 import React from 'react';
 import { MTablePagination, MTableSteppedPagination } from './components';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
@@ -24,18 +24,20 @@ export default class MaterialTable extends React.Component<any, any> {
           .filter((a: any) => a.tableData.filterValue)
           .map((a: any) => ({
             column: a,
-            operator: "=",
-            value: a.tableData.filterValue
+            operator: '=',
+            value: a.tableData.filterValue,
           })),
-        orderBy: renderState.columns.find((a: any) => a.tableData.id === renderState.orderBy),
+        orderBy: renderState.columns.find(
+          (a: any) => a.tableData.id === renderState.orderBy
+        ),
         orderDirection: renderState.orderDirection,
         page: 0,
         pageSize: calculatedProps.options.pageSize,
         search: renderState.searchText,
 
-        totalCount: 0
+        totalCount: 0,
       },
-      showAddRow: false
+      showAddRow: false,
     };
   }
 
@@ -52,7 +54,10 @@ export default class MaterialTable extends React.Component<any, any> {
     let defaultSortDirection = '';
     if (props) {
       defaultSortColumnIndex = props.columns.findIndex(a => a.defaultSort);
-      defaultSortDirection = defaultSortColumnIndex > -1 ? props.columns[defaultSortColumnIndex].defaultSort : '';
+      defaultSortDirection =
+        defaultSortColumnIndex > -1
+          ? props.columns[defaultSortColumnIndex].defaultSort
+          : '';
     }
 
     this.dataManager.setColumns(props.columns);
@@ -61,15 +66,17 @@ export default class MaterialTable extends React.Component<any, any> {
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);
       this.dataManager.changeApplyFilters(false);
-    }
-    else {
+    } else {
       this.dataManager.changeApplySearch(true);
       this.dataManager.changeApplyFilters(true);
       this.dataManager.setData(props.data);
     }
 
     isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
-    isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
+    isInit &&
+      this.dataManager.changeCurrentPage(
+        props.options.initialPage ? props.options.initialPage : 0
+      );
     isInit && this.dataManager.changePageSize(props.options.pageSize);
     isInit && this.dataManager.changePaging(props.options.paging);
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
@@ -98,64 +105,77 @@ export default class MaterialTable extends React.Component<any, any> {
             this.dataManager.changeRowEditing();
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: !this.state.showAddRow
+              showAddRow: !this.state.showAddRow,
             });
-          }
+          },
         });
       }
       if (calculatedProps.editable.onRowUpdate) {
         calculatedProps.actions.push(rowData => ({
           icon: calculatedProps.icons.Edit,
           tooltip: localization.editTooltip,
-          disabled: calculatedProps.editable.isEditable && !calculatedProps.editable.isEditable(rowData),
+          disabled:
+            calculatedProps.editable.isEditable &&
+            !calculatedProps.editable.isEditable(rowData),
           onClick: (e, rowData) => {
-            this.dataManager.changeRowEditing(rowData, "update");
+            this.dataManager.changeRowEditing(rowData, 'update');
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: false
+              showAddRow: false,
             });
-          }
+          },
         }));
       }
       if (calculatedProps.editable.onRowDelete) {
         calculatedProps.actions.push(rowData => ({
           icon: calculatedProps.icons.Delete,
           tooltip: localization.deleteTooltip,
-          disabled: calculatedProps.editable.isDeletable && !calculatedProps.editable.isDeletable(rowData),
+          disabled:
+            calculatedProps.editable.isDeletable &&
+            !calculatedProps.editable.isDeletable(rowData),
           onClick: (e, rowData) => {
-            this.dataManager.changeRowEditing(rowData, "delete");
+            this.dataManager.changeRowEditing(rowData, 'delete');
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: false
+              showAddRow: false,
             });
-          }
+          },
         }));
       }
     }
 
-    calculatedProps.components = { ...(MaterialTable as any).defaultProps.components, ...calculatedProps.components };
-    calculatedProps.icons = { ...(MaterialTable as any).defaultProps.icons, ...calculatedProps.icons };
-    calculatedProps.options = { ...(MaterialTable as any).defaultProps.options, ...calculatedProps.options };
+    calculatedProps.components = {
+      ...(MaterialTable as any).defaultProps.components,
+      ...calculatedProps.components,
+    };
+    calculatedProps.icons = {
+      ...(MaterialTable as any).defaultProps.icons,
+      ...calculatedProps.icons,
+    };
+    calculatedProps.options = {
+      ...(MaterialTable as any).defaultProps.options,
+      ...calculatedProps.options,
+    };
 
     return calculatedProps;
   }
 
-  isRemoteData = (props?: any) => !Array.isArray((props || this.props).data)
+  isRemoteData = (props?: any) => !Array.isArray((props || this.props).data);
 
-  onAllSelected = (checked) => {
+  onAllSelected = checked => {
     this.dataManager.changeAllSelected(checked);
     this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange());
-  }
+  };
 
   onChangeColumnHidden = (columnId, hidden) => {
     this.dataManager.changeColumnHidden(columnId, hidden);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
-  onChangeGroupOrder = (groupedColumn) => {
+  onChangeGroupOrder = groupedColumn => {
     this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   onChangeOrder = (orderBy, orderDirection) => {
     this.dataManager.changeOrder(orderBy, orderDirection);
@@ -168,13 +188,12 @@ export default class MaterialTable extends React.Component<any, any> {
       this.onQueryChange(query, () => {
         this.props.onOrderChange && this.props.onOrderChange(orderBy, orderDirection);
       });
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onOrderChange && this.props.onOrderChange(orderBy, orderDirection);
       });
     }
-  }
+  };
 
   onChangePage = (event, page) => {
     if (this.isRemoteData()) {
@@ -183,16 +202,15 @@ export default class MaterialTable extends React.Component<any, any> {
       this.onQueryChange(query, () => {
         this.props.onChangePage && this.props.onChangePage(page);
       });
-    }
-    else {
+    } else {
       this.dataManager.changeCurrentPage(page);
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onChangePage && this.props.onChangePage(page);
       });
     }
-  }
+  };
 
-  onChangeRowsPerPage = (event) => {
+  onChangeRowsPerPage = event => {
     const pageSize = event.target.value;
 
     this.dataManager.changePageSize(pageSize);
@@ -204,43 +222,43 @@ export default class MaterialTable extends React.Component<any, any> {
       this.onQueryChange(query, () => {
         this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(pageSize);
       });
-    }
-    else {
+    } else {
       this.dataManager.changeCurrentPage(0);
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(pageSize);
       });
     }
-  }
+  };
 
   onDragEnd = result => {
     this.dataManager.changeByDrag(result);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
-  onGroupExpandChanged = (path) => {
+  onGroupExpandChanged = path => {
     this.dataManager.changeGroupExpand(path);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   onGroupRemoved = (groupedColumn, index) => {
     const result = {
       combine: null,
-      destination: { droppableId: "headers", index: 0 },
+      destination: { droppableId: 'headers', index: 0 },
       draggableId: groupedColumn.tableData.id,
-      mode: "FLUID",
-      reason: "DROP",
-      source: { index, droppableId: "groups" },
-      type: "DEFAULT"
+      mode: 'FLUID',
+      reason: 'DROP',
+      source: { index, droppableId: 'groups' },
+      type: 'DEFAULT',
     };
     this.dataManager.changeByDrag(result);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   onEditingApproved = (mode, newData, oldData) => {
-    if (mode === "add") {
+    if (mode === 'add') {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowAdd(newData)
+        this.props.editable
+          .onRowAdd(newData)
           .then(result => {
             this.setState({ isLoading: false, showAddRow: false }, () => {
               if (this.isRemoteData()) {
@@ -252,81 +270,90 @@ export default class MaterialTable extends React.Component<any, any> {
             this.setState({ isLoading: false });
           });
       });
-    }
-    else if (mode === "update") {
+    } else if (mode === 'update') {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowUpdate(newData, oldData)
+        this.props.editable
+          .onRowUpdate(newData, oldData)
           .then(result => {
             this.dataManager.changeRowEditing(oldData);
-            this.setState({
-              isLoading: false,
-              ...this.dataManager.getRenderState()
-            }, () => {
-              if (this.isRemoteData()) {
-                this.onQueryChange(this.state.query);
+            this.setState(
+              {
+                isLoading: false,
+                ...this.dataManager.getRenderState(),
+              },
+              () => {
+                if (this.isRemoteData()) {
+                  this.onQueryChange(this.state.query);
+                }
               }
-            });
+            );
           })
           .catch(reason => {
             this.setState({ isLoading: false });
           });
       });
-
-    }
-    else if (mode === "delete") {
+    } else if (mode === 'delete') {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowDelete(oldData)
+        this.props.editable
+          .onRowDelete(oldData)
           .then(result => {
             this.dataManager.changeRowEditing(oldData);
-            this.setState({
-              isLoading: false,
-              ...this.dataManager.getRenderState()
-            }, () => {
-              if (this.isRemoteData()) {
-                this.onQueryChange(this.state.query);
+            this.setState(
+              {
+                isLoading: false,
+                ...this.dataManager.getRenderState(),
+              },
+              () => {
+                if (this.isRemoteData()) {
+                  this.onQueryChange(this.state.query);
+                }
               }
-            });
+            );
           })
           .catch(reason => {
             this.setState({ isLoading: false });
           });
       });
     }
-  }
+  };
 
   onEditingCanceled = (mode, rowData) => {
-    if (mode === "add") {
+    if (mode === 'add') {
       this.setState({ showAddRow: false });
-    }
-    else if (mode === "update" || mode === "delete") {
+    } else if (mode === 'update' || mode === 'delete') {
       this.dataManager.changeRowEditing(rowData);
       this.setState(this.dataManager.getRenderState());
     }
-  }
+  };
 
   onQueryChange = (query?: any, callback?: any) => {
     query = { ...this.state.query, ...query };
 
     this.setState({ isLoading: true }, () => {
-      this.props.data(query).then((result) => {
+      this.props.data(query).then(result => {
         query.totalCount = result.totalCount;
         query.page = result.page;
         this.dataManager.setData(result.data);
-        this.setState({
-          isLoading: false,
-          ...this.dataManager.getRenderState(),
-          query
-        }, () => {
-          callback && callback();
-        });
+        this.setState(
+          {
+            isLoading: false,
+            ...this.dataManager.getRenderState(),
+            query,
+          },
+          () => {
+            callback && callback();
+          }
+        );
       });
     });
-  }
+  };
 
   onRowSelected = (event, path, dataClicked) => {
     this.dataManager.changeRowSelected(event.target.checked, path);
-    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked));
-  }
+    this.setState(this.dataManager.getRenderState(), () =>
+      this.onSelectionChange(dataClicked)
+    );
+  };
 
   onSelectionChange = (dataClicked?: any) => {
     if (this.props.onSelectionChange) {
@@ -345,9 +372,10 @@ export default class MaterialTable extends React.Component<any, any> {
       findSelecteds(this.state.originalData);
       this.props.onSelectionChange(selectedRows, dataClicked);
     }
-  }
+  };
 
-  onSearchChange = searchText => this.setState({ searchText }, this.onSearchChangeDebounce)
+  onSearchChange = searchText =>
+    this.setState({ searchText }, this.onSearchChangeDebounce);
 
   onSearchChangeDebounce = debounce(() => {
     this.dataManager.changeSearchText(this.state.searchText);
@@ -358,16 +386,15 @@ export default class MaterialTable extends React.Component<any, any> {
       query.search = this.state.searchText;
 
       this.onQueryChange(query);
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState());
     }
-  }, this.props.options.debounceInterval)
+  }, this.props.options.debounceInterval);
 
   onFilterChange = (columnId, value) => {
     this.dataManager.changeFilterValue(columnId, value);
     this.setState({}, this.onFilterChangeDebounce);
-  }
+  };
 
   onFilterChangeDebounce = debounce(() => {
     if (this.isRemoteData()) {
@@ -376,33 +403,36 @@ export default class MaterialTable extends React.Component<any, any> {
         .filter(a => a.tableData.filterValue)
         .map(a => ({
           column: a,
-          operator: "=",
-          value: a.tableData.filterValue
+          operator: '=',
+          value: a.tableData.filterValue,
         }));
 
       this.onQueryChange(query);
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState());
     }
-  }, this.props.options.debounceInterval)
+  }, this.props.options.debounceInterval);
 
   onTreeExpandChanged = (path, data) => {
     this.dataManager.changeTreeExpand(path);
     this.setState(this.dataManager.getRenderState(), () => {
-      this.props.onTreeExpandChange && this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
+      this.props.onTreeExpandChange &&
+        this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
     });
-  }
+  };
 
   onToggleDetailPanel = (path, render) => {
     this.dataManager.changeDetailPanelVisibility(path, render);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   renderFooter() {
     const props = this.getProps();
     if (props.options.paging) {
-      const localization = { ...(MaterialTable as any).defaultProps.localization.pagination, ...this.props.localization.pagination };
+      const localization = {
+        ...(MaterialTable as any).defaultProps.localization.pagination,
+        ...this.props.localization.pagination,
+      };
       return (
         <Table>
           <TableFooter style={{ display: 'grid' }}>
@@ -414,22 +444,53 @@ export default class MaterialTable extends React.Component<any, any> {
                   caption: props.classes.paginationCaption,
                   selectRoot: props.classes.paginationSelectRoot,
                 }}
-                style={{ float: props.theme.direction === "rtl" ? "" : "right", overflowX: 'auto' }}
+                style={{
+                  float: props.theme.direction === 'rtl' ? '' : 'right',
+                  overflowX: 'auto',
+                }}
                 colSpan={3}
-                count={this.isRemoteData() ? this.state.query.totalCount : this.state.data.length}
+                count={
+                  this.isRemoteData()
+                    ? this.state.query.totalCount
+                    : this.state.data.length
+                }
                 icons={props.icons}
                 rowsPerPage={this.state.pageSize}
                 rowsPerPageOptions={props.options.pageSizeOptions}
                 SelectProps={{
-                  renderValue: value => <div style={{ padding: '0px 5px' }}>{value + ' ' + localization.labelRowsSelect + ' '}</div>
+                  renderValue: value => (
+                    <div style={{ padding: '0px 5px' }}>
+                      {value + ' ' + localization.labelRowsSelect + ' '}
+                    </div>
+                  ),
                 }}
-                page={this.isRemoteData() ? this.state.query.page : this.state.currentPage}
+                page={
+                  this.isRemoteData() ? this.state.query.page : this.state.currentPage
+                }
                 onChangePage={this.onChangePage}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
-                ActionsComponent={(subProps) => props.options.paginationType === 'normal' ?
-                  <MTablePagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons}/> :
-                  <MTableSteppedPagination {...subProps} icons={props.icons} localization={localization} />}
-                labelDisplayedRows={(row) => localization.labelDisplayedRows.replace('{from}', row.from).replace('{to}', row.to).replace('{count}', row.count)}
+                ActionsComponent={subProps =>
+                  props.options.paginationType === 'normal' ? (
+                    <MTablePagination
+                      {...subProps}
+                      icons={props.icons}
+                      localization={localization}
+                      showFirstLastPageButtons={props.options.showFirstLastPageButtons}
+                    />
+                  ) : (
+                    <MTableSteppedPagination
+                      {...subProps}
+                      icons={props.icons}
+                      localization={localization}
+                    />
+                  )
+                }
+                labelDisplayedRows={row =>
+                  localization.labelDisplayedRows
+                    .replace('{from}', row.from)
+                    .replace('{to}', row.to)
+                    .replace('{count}', row.count)
+                }
                 labelRowsPerPage={localization.labelRowsPerPage}
               />
             </TableRow>
@@ -444,12 +505,30 @@ export default class MaterialTable extends React.Component<any, any> {
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
-        <props.components.Container style={{ position: 'relative', ...props.style }}>
-          {props.options.toolbar &&
+        <props.components.Container
+          style={
+            this.props.options.flexTable
+              ? {
+                  display: 'flex',
+                  flex: '1 1 auto',
+                  flexDirection: 'column',
+                  position: 'relative',
+                  ...props.style,
+                }
+              : { position: 'relative', ...props.style }
+          }
+        >
+          {props.options.toolbar && (
             <props.components.Toolbar
               actions={props.actions}
               components={props.components}
-              selectedRows={this.state.selectedCount > 0 ? this.state.originalData.filter(a => { return a.tableData.checked }) : []}
+              selectedRows={
+                this.state.selectedCount > 0
+                  ? this.state.originalData.filter(a => {
+                      return a.tableData.checked;
+                    })
+                  : []
+              }
               columns={this.state.columns}
               columnsButton={props.options.columnsButton}
               icons={props.icons}
@@ -471,38 +550,68 @@ export default class MaterialTable extends React.Component<any, any> {
               title={props.title}
               onSearchChanged={this.onSearchChange}
               onColumnsChanged={this.onChangeColumnHidden}
-              localization={{ ...(MaterialTable as any).defaultProps.localization.toolbar, ...this.props.localization.toolbar }}
+              localization={{
+                ...(MaterialTable as any).defaultProps.localization.toolbar,
+                ...this.props.localization.toolbar,
+              }}
             />
-          }
-          {props.options.grouping &&
+          )}
+          {props.options.grouping && (
             <props.components.Groupbar
               icons={props.icons}
-              localization={{ ...(MaterialTable as any).defaultProps.localization.grouping, ...props.localization.grouping }}
+              localization={{
+                ...(MaterialTable as any).defaultProps.localization.grouping,
+                ...props.localization.grouping,
+              }}
               groupColumns={this.state.columns
                 .filter(col => col.tableData.groupOrder > -1)
-                .sort((col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder)
-              }
+                .sort(
+                  (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+                )}
               onSortChanged={this.onChangeGroupOrder}
               onGroupRemoved={this.onGroupRemoved}
             />
-          }
-          <ScrollBar double={props.options.doubleHorizontalScroll}>
+          )}
+          <ScrollBar
+            double={props.options.doubleHorizontalScroll}
+            flexTable={this.props.options.flexTable}
+          >
             <Droppable droppableId="headers" direction="horizontal">
               {(provided, snapshot) => (
                 <div ref={provided.innerRef}>
-                  <div style={{ maxHeight: props.options.maxBodyHeight, overflowY: 'auto' }}>
+                  <div
+                    style={
+                      this.props.options.flexTable
+                        ? {}
+                        : { maxHeight: props.options.maxBodyHeight, overflowY: 'auto' }
+                    }
+                  >
                     <Table>
-                      {props.options.header &&
+                      {props.options.header && (
                         <props.components.Header
-                          localization={{ ...(MaterialTable as any).defaultProps.localization.header, ...this.props.localization.header }}
+                          localization={{
+                            ...(MaterialTable as any).defaultProps.localization.header,
+                            ...this.props.localization.header,
+                          }}
                           columns={this.state.columns}
                           hasSelection={props.options.selection}
                           headerStyle={props.options.headerStyle}
                           selectedCount={this.state.selectedCount}
-                          dataCount={props.parentChildData ? this.state.treefiedDataLength : this.state.data.length}
+                          dataCount={
+                            props.parentChildData
+                              ? this.state.treefiedDataLength
+                              : this.state.data.length
+                          }
                           hasDetailPanel={Boolean(props.detailPanel)}
-                          detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
-                          showActionsColumn={props.actions && props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0}
+                          detailPanelColumnAlignment={
+                            props.options.detailPanelColumnAlignment
+                          }
+                          showActionsColumn={
+                            props.actions &&
+                            props.actions.filter(
+                              a => !a.isFreeAction && !this.props.options.selection
+                            ).length > 0
+                          }
                           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
                           orderBy={this.state.orderBy}
                           orderDirection={this.state.orderDirection}
@@ -513,7 +622,7 @@ export default class MaterialTable extends React.Component<any, any> {
                           grouping={props.options.grouping}
                           isTreeData={this.props.parentChildData !== undefined}
                         />
-                      }
+                      )}
                       <props.components.Body
                         actions={props.actions}
                         components={props.components}
@@ -534,10 +643,15 @@ export default class MaterialTable extends React.Component<any, any> {
                         onTreeExpandChanged={this.onTreeExpandChanged}
                         onEditingCanceled={this.onEditingCanceled}
                         onEditingApproved={this.onEditingApproved}
-                        localization={{ ...(MaterialTable as any).defaultProps.localization.body, ...this.props.localization.body }}
+                        localization={{
+                          ...(MaterialTable as any).defaultProps.localization.body,
+                          ...this.props.localization.body,
+                        }}
                         onRowClick={this.props.onRowClick}
                         showAddRow={this.state.showAddRow}
-                        hasAnyEditingRow={Boolean(this.state.lastEditingRow || this.state.showAddRow)}
+                        hasAnyEditingRow={Boolean(
+                          this.state.lastEditingRow || this.state.showAddRow
+                        )}
                         hasDetailPanel={Boolean(props.detailPanel)}
                         treeDataMaxLevel={this.state.treeDataMaxLevel}
                       />
@@ -547,39 +661,59 @@ export default class MaterialTable extends React.Component<any, any> {
                 </div>
               )}
             </Droppable>
-
           </ScrollBar>
-          {(this.state.isLoading || props.isLoading) && props.options.loadingType === "linear" &&
-            <div style={{ position: 'relative', width: '100%' }}>
-              <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%' }}>
-                <LinearProgress />
+          {(this.state.isLoading || props.isLoading) &&
+            props.options.loadingType === 'linear' && (
+              <div style={{ position: 'relative', width: '100%' }}>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    height: '100%',
+                    width: '100%',
+                  }}
+                >
+                  <LinearProgress />
+                </div>
               </div>
-            </div>
-          }
+            )}
+          {this.props.preFooterRow && this.props.preFooterRow}
           {this.renderFooter()}
 
-          {(this.state.isLoading || props.isLoading) && props.options.loadingType === 'overlay' &&
-            <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%', zIndex: 11 }}>
-              <props.components.OverlayLoading theme={props.theme} />
-            </div>
-          }
+          {(this.state.isLoading || props.isLoading) &&
+            props.options.loadingType === 'overlay' && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  height: '100%',
+                  width: '100%',
+                  zIndex: 11,
+                }}
+              >
+                <props.components.OverlayLoading theme={props.theme} />
+              </div>
+            )}
         </props.components.Container>
       </DragDropContext>
     );
   }
 }
 
-const ScrollBar = ({ double, children }) => {
+const ScrollBar = ({ double, flexTable, children }) => {
   if (double) {
+    return <DoubleScrollbar>{children}</DoubleScrollbar>;
+  } else {
     return (
-      <DoubleScrollbar>
-        {children}
-      </DoubleScrollbar>
-    );
-  }
-  else {
-    return (
-      <div style={{ overflowX: 'auto' }}>
+      <div
+        style={
+          flexTable
+            ? { height: '0px', flex: '2 1 auto', overflow: 'auto' }
+            : { overflowX: 'auto' }
+        }
+      >
         {children}
       </div>
     );


### PR DESCRIPTION
added a way to add a totals row (or any other kind of row) between the table rows and the pagination row and added a way to make the table flex and scroll using available space.

also added `Flex-Scroll Table` to storybook eample

## Related Issue
Relate the Github issue with this PR using `#`

## Description
Simple words to describe the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)